### PR TITLE
Refactor login and types for email-based auth and API changes

### DIFF
--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -4,12 +4,13 @@ export interface User {
   nickname: string;
   university?: string | null;
   email?: string | null;
+  is_active?: boolean;
 }
 
 export interface LoginResponse {
-  access: string;
-  refresh: string;
-  user: User;
+  access_token: string;
+  refresh_token: string;
+  token_type: string;
 }
 
 export interface CheckUsernameResponse {
@@ -21,13 +22,6 @@ export interface RegisterResponse {
   user: User;
   message: string;
 }
-
-export interface LoginResponse {
-  access: string;
-  refresh: string;
-  user: User;
-}
-
 export interface SignupRequest {
   username: string;
   password: string;

--- a/frontend/src/types/comment.ts
+++ b/frontend/src/types/comment.ts
@@ -1,9 +1,9 @@
 export interface Comment {
   id: number;
-  post: number;
+  post_id: number;      
   content: string;
   author_nickname: string;
-  parent: number | null;
+  parent_id: number | null; 
   children?: Comment[];
   created_at: string;
   updated_at?: string;


### PR DESCRIPTION
Updated the login page to use email instead of username for authentication and adjusted token handling to match new API response fields. Modified related type definitions in auth.ts and comment.ts to align with backend changes, including renaming fields and adding new properties.