### PR TITLE
Fix comment link to use correct post_id property

### DIFF
--- a/frontend/src/app/mypage/page.tsx
+++ b/frontend/src/app/mypage/page.tsx
@@ -326,7 +326,7 @@ function CommentList({ comments }: CommentListProps) {
       {comments.map((comment) => (
         <Link
           key={comment.id}
-          href={`/posts/${comment.post}`}
+          href={`/posts/${comment.post_id}`}
           className="block p-5 bg-white border border-gray-100 rounded-xl hover:bg-gray-50 hover:border-gray-200 transition duration-200"
         >
           <p className="text-gray-800 mb-3 line-clamp-2 leading-relaxed">


### PR DESCRIPTION
Updated the CommentList component to use comment.post_id instead of comment.post for the post link. This ensures the link navigates to the correct post associated with each comment.